### PR TITLE
상품 상세 페이지 이동 방식 변경

### DIFF
--- a/src/Homepage.test.jsx
+++ b/src/Homepage.test.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { render } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
+
 import Homepage from './Homepage';
 
 import categoriesFixture, {

--- a/src/Homepage.test.jsx
+++ b/src/Homepage.test.jsx
@@ -4,8 +4,6 @@ import { useSelector } from 'react-redux';
 
 import { render } from '@testing-library/react';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import Homepage from './Homepage';
 
 import categoriesFixture, {
@@ -24,9 +22,7 @@ describe('Homepage', () => {
 
   function renderHomepage() {
     return render((
-      <MemoryRouter>
-        <Homepage />
-      </MemoryRouter>
+      <Homepage />
     ));
   }
 

--- a/src/HomepageContainer.test.jsx
+++ b/src/HomepageContainer.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import { useDispatch, useSelector } from 'react-redux';
 
 import { render } from '@testing-library/react';
@@ -32,9 +30,7 @@ describe('HomepageContainer', () => {
 
   it('loads initial data', () => {
     render((
-      <MemoryRouter>
-        <HomepageContainer />
-      </MemoryRouter>
+      <HomepageContainer />
     ));
 
     expect(dispatch).toBeCalled();

--- a/src/ProductDetailContainer.test.jsx
+++ b/src/ProductDetailContainer.test.jsx
@@ -4,8 +4,6 @@ import { render } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import ProductDetailContainer from './ProductDetailContainer';
 
 import { productFixture } from '../fixtures/products';
@@ -28,9 +26,7 @@ describe('ProductDetailContainer', () => {
 
   function renderProductDetailContainer() {
     return render((
-      <MemoryRouter>
-        <ProductDetailContainer params={productFixture.id} />
-      </MemoryRouter>
+      <ProductDetailContainer params={productFixture.id} />
     ));
   }
 

--- a/src/ProductItem.jsx
+++ b/src/ProductItem.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
-export default function ProductItem({ product }) {
+export default function ProductItem({ product, handleClick }) {
   return (
     <li>
-      <p>{product.title}</p>
-      <p>{product.price}</p>
+      <a href="" onClick={handleClick}>
+        <p>{product.title}</p>
+        <p>{product.price}</p>
+      </a>
     </li>
   );
 }

--- a/src/ProductItem.test.jsx
+++ b/src/ProductItem.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import ProductItem from './ProductItem';
+
+import { productFixture } from '../fixtures/products';
+
+describe('ProductItem', () => {
+  const handleClick = jest.fn();
+
+  it('listens the click event', () => {
+    const { getByText } = render((
+      <ProductItem
+        product={productFixture}
+        handleClick={handleClick}
+      />
+    ));
+
+    fireEvent.click(getByText(productFixture.title));
+
+    expect(handleClick).toBeCalled();
+  });
+});

--- a/src/ProductItemContainer.jsx
+++ b/src/ProductItemContainer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { useHistory } from 'react-router-dom';
+
+import ProductItem from './ProductItem';
+
+export default function ProductItemContainer({ product }) {
+  const history = useHistory();
+
+  function handleClick() {
+    history.push(`/products/${product.id}`);
+  }
+
+  return (
+    <ProductItem product={product} handleClick={handleClick} />
+  );
+}

--- a/src/ProductItemContainer.jsx
+++ b/src/ProductItemContainer.jsx
@@ -7,7 +7,8 @@ import ProductItem from './ProductItem';
 export default function ProductItemContainer({ product }) {
   const history = useHistory();
 
-  function handleClick() {
+  function handleClick(event) {
+    event.preventDefault();
     history.push(`/products/${product.id}`);
   }
 

--- a/src/ProductItemContainer.test.jsx
+++ b/src/ProductItemContainer.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import ProductItemContainer from './ProductItemContainer';
+
+import { productFixture } from '../fixtures/products';
+
+const mockPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useHistory() {
+    return { push: mockPush };
+  },
+}));
+
+describe('ProductItemContainer', () => {
+  function renderProductItemContainer() {
+    return render((
+      <ProductItemContainer product={productFixture} />
+    ));
+  }
+
+  it('renders the ProductItem', () => {
+    const { container } = renderProductItemContainer();
+
+    expect(container).toHaveTextContent(productFixture.title);
+    expect(container).toHaveTextContent(productFixture.price);
+  });
+
+  it('listens the click event', () => {
+    const { getByText } = renderProductItemContainer();
+
+    fireEvent.click(getByText(productFixture.title));
+
+    expect(mockPush).toBeCalledWith(`/products/${productFixture.id}`);
+  });
+});

--- a/src/ProductList.jsx
+++ b/src/ProductList.jsx
@@ -5,17 +5,6 @@ import { useHistory } from 'react-router-dom';
 import ProductItem from './ProductItem';
 
 export default function ProductList({ products }) {
-  const history = useHistory();
-
-  function handleClick(product) {
-    const url = `/products/${product.id}`;
-
-    return (event) => {
-      event.preventDefault();
-      history.push(url);
-    };
-  }
-
   return (
     <>
       <h2>상품</h2>
@@ -24,7 +13,6 @@ export default function ProductList({ products }) {
           <ProductItem
             key={product.id}
             product={product}
-            handleClick={handleClick(product)}
           />
         ))}
       </ul>

--- a/src/ProductList.jsx
+++ b/src/ProductList.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import ProductItem from './ProductItem';
 
 export default function ProductList({ products }) {
+  const history = useHistory();
+
+  function handleClick(product) {
+    const url = `/products/${product.id}`;
+
+    return (event) => {
+      event.preventDefault();
+      history.push(url);
+    };
+  }
+
   return (
     <>
       <h2>상품</h2>
       <ul>
         {products.map((product) => (
-          <Link
+          <ProductItem
             key={product.id}
-            to={`/products/${product.id}`}
-          >
-            <ProductItem
-              product={product}
-            />
-          </Link>
+            product={product}
+            handleClick={handleClick(product)}
+          />
         ))}
       </ul>
     </>

--- a/src/ProductList.jsx
+++ b/src/ProductList.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { useHistory } from 'react-router-dom';
-
-import ProductItem from './ProductItem';
+import ProductItemContainer from './ProductItemContainer';
 
 export default function ProductList({ products }) {
   return (
@@ -10,7 +8,7 @@ export default function ProductList({ products }) {
       <h2>상품</h2>
       <ul>
         {products.map((product) => (
-          <ProductItem
+          <ProductItemContainer
             key={product.id}
             product={product}
           />

--- a/src/ProductListContainer.test.jsx
+++ b/src/ProductListContainer.test.jsx
@@ -4,8 +4,6 @@ import { render } from '@testing-library/react';
 
 import { useSelector } from 'react-redux';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import ProductListContainer from './ProductListContainer';
 
 import productsFixture from '../fixtures/products';
@@ -19,9 +17,7 @@ jest.mock('react-redux');
 describe('ProductListContainer', () => {
   function renderProductListContainer() {
     return render((
-      <MemoryRouter>
-        <ProductListContainer />
-      </MemoryRouter>
+      <ProductListContainer />
     ));
   }
 

--- a/src/ProductListContainer.test.jsx
+++ b/src/ProductListContainer.test.jsx
@@ -21,13 +21,15 @@ describe('ProductListContainer', () => {
     ));
   }
 
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      products: productsFixture,
+      selectedCategory: given.selectedCategory,
+    }));
+  });
+
   context('without selected category', () => {
-    beforeEach(() => {
-      useSelector.mockImplementation((selector) => selector({
-        products: productsFixture,
-        selectedCategory: null,
-      }));
-    });
+    given('selectedCategory', () => null);
 
     it('renders the all products', () => {
       const { container } = renderProductListContainer();
@@ -40,12 +42,7 @@ describe('ProductListContainer', () => {
   });
 
   context('with selected category', () => {
-    beforeEach(() => {
-      useSelector.mockImplementation((selector) => selector({
-        products: productsFixture,
-        selectedCategory: selectedCategoryFixture,
-      }));
-    });
+    given('selectedCategory', () => selectedCategoryFixture);
 
     it('renders the products which is filtered by category', () => {
       function getFilteredProduct(category) {

--- a/src/ProductListContainer.test.jsx
+++ b/src/ProductListContainer.test.jsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 
 import { MemoryRouter } from 'react-router-dom';
+
 import ProductListContainer from './ProductListContainer';
 
 import productsFixture from '../fixtures/products';


### PR DESCRIPTION
- 상품 상세 페이지 이동 시 react-router의 link를 사용하면 테스트가 과도하게 복잡해지는 것 같아서 제거했습니다.
- 좀 더 간단하게 사용하기 위해 history에 알맞는 url을 push하는 함수를 작성하고 이 함수를 이벤트 핸들러에 전달하도록 변경했습니다.