### PR TITLE
주문폼 초기화

### DIFF
--- a/src/slice.js
+++ b/src/slice.js
@@ -7,6 +7,13 @@ import {
   requestOrder,
 } from '../services/api';
 
+const initialOrderForm = {
+  username: '',
+  phoneNumber: '',
+  amount: 0,
+  address: '',
+};
+
 const { actions, reducer } = createSlice({
   name: 'application',
   initialState: {
@@ -14,12 +21,7 @@ const { actions, reducer } = createSlice({
     selectedCategory: null,
     products: [],
     product: null,
-    orderForm: {
-      username: '',
-      phoneNumber: '',
-      amount: 0,
-      address: '',
-    },
+    orderForm: initialOrderForm,
     orderResult: null,
   },
   reducers: {
@@ -61,6 +63,13 @@ const { actions, reducer } = createSlice({
       };
     },
 
+    clearOrderForm(state) {
+      return {
+        ...state,
+        orderForm: initialOrderForm,
+      };
+    },
+
     setOrderResult(state, { payload: orderResult }) {
       return {
         ...state,
@@ -85,6 +94,7 @@ export const {
   changeOrderForm,
   setOrderResult,
   clearOrderResult,
+  clearOrderForm,
 } = actions;
 
 export function loadInitialState() {

--- a/src/slice.js
+++ b/src/slice.js
@@ -128,6 +128,7 @@ export function orderProduct() {
     });
 
     dispatch(setOrderResult(orderResult));
+    dispatch(clearOrderForm());
   };
 }
 

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -212,6 +212,7 @@ describe('async actions', () => {
       const actions = store.getActions();
 
       expect(actions[0]).toEqual(setOrderResult(true));
+      expect(actions[1]).toEqual(clearOrderForm());
     });
   });
 });

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -13,6 +13,7 @@ import reducer, {
   setOrderResult,
   clearOrderResult,
   orderProduct,
+  clearOrderForm,
 } from './slice';
 
 import categoriesFixture from '../fixtures/categories';
@@ -135,6 +136,28 @@ describe('reducer', () => {
     const state = reducer(initialState, clearOrderResult());
 
     expect(state.orderResult).toBe(null);
+  });
+
+  describe('clearOrderForm', () => {
+    const initialState = {
+      orderForm: {
+        username: '홍길동',
+        phoneNumber: '010-0000-0000',
+        amount: 10,
+        address: '지구',
+      },
+    };
+
+    const cleanedForm = {
+      username: '',
+      phoneNumber: '',
+      amount: 0,
+      address: '',
+    };
+
+    const state = reducer(initialState, clearOrderForm());
+
+    expect(state.orderForm).toEqual(cleanedForm);
   });
 });
 

--- a/test/order_form_test.js
+++ b/test/order_form_test.js
@@ -1,15 +1,25 @@
 Feature('ProductDetail');
 
+const formData = {
+  username: '홍길동',
+  phoneNumber: '010-0000-0000',
+  amount: '2',
+  address: '화성',
+};
+
 Scenario('주문서를 작성해서 주문할 수 있다.', (I) => {
   I.amOnPage('/products/1');
 
-  I.fillField('username', '홍길동');
-  I.fillField('phoneNumber', '010-0000-0000');
-  I.fillField('amount', '2');
-  I.fillField('address', '지구 어딘가 저편에서');
+  Object.entries(formData).forEach(([fieldName, value]) => {
+    I.fillField(fieldName, value);
+  });
 
   I.click('주문하기');
 
   I.see('주문이 완료됐습니다.');
   I.see('국민은행: 00-0000-0000-00');
+
+  Object.entries(formData).forEach(([fieldName, value]) => {
+    I.dontSeeInField(fieldName, value);
+  });
 });


### PR DESCRIPTION
사용자가 주문 후 다른 상품에 이동했을 때 깨끗한 주문폼 양식을 보게 하기 위해 기능을 개선했습니다.

- 기존: 주문 요청 후에도 주문폼에 이전 주문 요청 정보가 남아있음
- 변경후: 주문 요청이 성공하면, 주문 성공여부에 관계 없이 주문폼 초기화