### PR TITLE
상품 상세 페이지 이동 시 주문 결과 초기화

### DIFF
--- a/src/OrderResult.jsx
+++ b/src/OrderResult.jsx
@@ -5,6 +5,12 @@ import OrderSuccessMessage from './OrderSuccessMessage';
 import OrderFailMessage from './OrderFailMessage';
 
 export default function OrderResult({ orderResult }) {
+  if (orderResult === null) {
+    return (
+      <p />
+    );
+  }
+
   return (
     <div>
       {

--- a/src/OrderResult.test.jsx
+++ b/src/OrderResult.test.jsx
@@ -22,4 +22,20 @@ describe('OrderResult', () => {
       expect(container).not.toHaveTextContent(orderFailMessage);
     });
   });
+
+  context('when order result is success', () => {
+    it('renders the success message', () => {
+      const { container } = renderOrderResult(null);
+
+      expect(container).not.toHaveTextContent(orderSuccessMessage);
+    });
+  });
+
+  context('when order result is fail', () => {
+    it('renders the fail message', () => {
+      const { container } = renderOrderResult(null);
+
+      expect(container).not.toHaveTextContent(orderFailMessage);
+    });
+  });
 });

--- a/src/OrderResult.test.jsx
+++ b/src/OrderResult.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import OrderResult from './OrderResult';
+
+describe('OrderResult', () => {
+  const orderSuccessMessage = '주문이 완료됐습니다.';
+  const orderFailMessage = '주문이 실패했습니다.';
+
+  function renderOrderResult(orderResult) {
+    return render(
+      <OrderResult orderResult={orderResult} />,
+    );
+  }
+
+  context('when order result is null', () => {
+    it('renders nothing', () => {
+      const { container } = renderOrderResult(null);
+
+      expect(container).not.toHaveTextContent(orderSuccessMessage);
+      expect(container).not.toHaveTextContent(orderFailMessage);
+    });
+  });
+});

--- a/src/ProductDetailContainer.jsx
+++ b/src/ProductDetailContainer.jsx
@@ -4,7 +4,10 @@ import { useParams } from 'react-router-dom';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { loadProductDetail } from './slice';
+import {
+  clearOrderResult,
+  loadProductDetail,
+} from './slice';
 
 import ProductDetail from './ProductDetail';
 
@@ -14,6 +17,7 @@ export default function ProductDetailContainer({ params }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    dispatch(clearOrderResult());
     dispatch(loadProductDetail(id));
   }, []);
 

--- a/src/ProductDetailContainer.test.jsx
+++ b/src/ProductDetailContainer.test.jsx
@@ -49,10 +49,10 @@ describe('ProductDetailContainer', () => {
       expect(container).toHaveTextContent(`가격: ${productFixture.price}`);
     });
 
-    it('loads the product detail', () => {
+    it('loads the product detail and clear order result', () => {
       renderProductDetailContainer();
 
-      expect(dispatch).toBeCalled();
+      expect(dispatch).toBeCalledTimes(2);
     });
   });
 

--- a/test/order_form_test.js
+++ b/test/order_form_test.js
@@ -23,3 +23,21 @@ Scenario('주문서를 작성해서 주문할 수 있다.', (I) => {
     I.dontSeeInField(fieldName, value);
   });
 });
+
+Scenario('주문 완료 후 다른 상품 상세 조회 했을 때, 이전 주문 결과가 보이지 않는다.', (I) => {
+  I.amOnPage('/products/1');
+
+  Object.entries(formData).forEach(([fieldName, value]) => {
+    I.fillField(fieldName, value);
+  });
+
+  I.click('주문하기');
+  I.see('주문이 완료됐습니다.');
+  I.see('국민은행: 00-0000-0000-00');
+
+  I.click('YenTopper');
+  I.click('생일축하해');
+
+  I.dontSee('주문이 완료됐습니다.');
+  I.dontSee('국민은행: 00-0000-0000-00');
+});


### PR DESCRIPTION
이전에는 사용자가 주문 후 다른 상품 상세 페이지를 접속했을 때 이전 주문 결과가 남아있었습니다.
이 부분이 사용자가 주문하지 않는 상품을 주문했다고 오해를 불러일으킬 수 있기 때문에 사용자 경험 개선 차원에서 기능을 변경했습니다.
변경 후 상품 상세 페이지 이동 시 상품 주문 결과가 매번 초기화 됩니다.