### PR TITLE
리액트 라우터 기본 경로 설정

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,7 +14,7 @@ import App from './App';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <BrowserRouter>
+      <BrowserRouter basename={process.env.BASE_PATH}>
         <App />
       </BrowserRouter>
     </Provider>


### PR DESCRIPTION
- 현재 배포된 페이지의 하부 경로가 존재하기 때문에 리액트 라우터의 basepath 경로 지정