### PR TITLE
Mixed Contents 해결

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -12,6 +12,9 @@ exports.config = {
       url: 'http://localhost:8080',
       show: true,
       windowSize: '1200x900',
+      chrome: {
+        ignoreHTTPSErrors: true,
+      },
     },
   },
   include: {

--- a/services/api.js
+++ b/services/api.js
@@ -1,4 +1,4 @@
-const API_SERVER = 'http://3.34.86.117:8000';
+const API_SERVER = 'https://3.34.86.117:8000';
 
 const headers = {
   'Content-Security-Policy': 'upgrade-insecure-requests',


### PR DESCRIPTION
- mixed contents 에러를 해결하기 위해 백엔드 서버 ssl 적용
- ssl 적용된 서버로 경로 변경